### PR TITLE
Update helm chart so that network aware plugin becomes usable

### DIFF
--- a/manifests/install/charts/as-a-second-scheduler/templates/configmap.yaml
+++ b/manifests/install/charts/as-a-second-scheduler/templates/configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.plugins.enabled }}
+{{- if .Values.plugins }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -13,16 +13,9 @@ data:
     profiles:
     # Compose all plugins in one profile
     - schedulerName: {{ .Values.scheduler.name }}
-      plugins:
-        multiPoint:
-          enabled:
-          {{- range $.Values.plugins.enabled }}
-          - name: {{ title . }}
-          {{- end }}
-          disabled:
-          {{- range $.Values.plugins.disabled }}
-          - name: {{ title . }}
-          {{- end }}
+      {{- if .Values.plugins }}
+      plugins: {{ toYaml $.Values.plugins | nindent 8 }}
+      {{- end }}
       {{- if $.Values.pluginConfig }}
       pluginConfig: {{ toYaml $.Values.pluginConfig | nindent 6 }}
       {{- end }}

--- a/manifests/install/charts/as-a-second-scheduler/templates/rbac.yaml
+++ b/manifests/install/charts/as-a-second-scheduler/templates/rbac.yaml
@@ -67,12 +67,12 @@ rules:
   resources: ["podgroups", "elasticquotas", "podgroups/status", "elasticquotas/status"]
   verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
 # for network-aware plugins add the following lines (scheduler-plugins v.0.25.7)
-#- apiGroups: [ "appgroup.diktyo.x-k8s.io" ]
-#  resources: [ "appgroups" ]
-#  verbs: [ "get", "list", "watch", "create", "delete", "update", "patch" ]
-#- apiGroups: [ "networktopology.diktyo.x-k8s.io" ]
-#  resources: [ "networktopologies" ]
-#  verbs: [ "get", "list", "watch", "create", "delete", "update", "patch" ]
+- apiGroups: [ "appgroup.diktyo.x-k8s.io" ]
+  resources: [ "appgroups" ]
+  verbs: [ "get", "list", "watch", "create", "delete", "update", "patch" ]
+- apiGroups: [ "networktopology.diktyo.x-k8s.io" ]
+  resources: [ "networktopologies" ]
+  verbs: [ "get", "list", "watch", "create", "delete", "update", "patch" ]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/install/charts/as-a-second-scheduler/values.yaml
+++ b/manifests/install/charts/as-a-second-scheduler/values.yaml
@@ -34,8 +34,8 @@ plugins:
     enabled: # A higher weight is given to NetworkOverhead to favor allocation schemes with lower latency.
       - name: NetworkOverhead
         weight: 5
-      - name: BalancedAllocation
-        weight: 1
+      # - name: BalancedAllocation
+      #   weight: 1
 
 # Customize the enabled plugins' config.
 # Refer to the "pluginConfig" section of manifests/<plugin>/scheduler-config.yaml.

--- a/manifests/install/charts/as-a-second-scheduler/values.yaml
+++ b/manifests/install/charts/as-a-second-scheduler/values.yaml
@@ -17,18 +17,37 @@ controller:
 # as they need extra RBAC privileges on metrics.k8s.io.
 
 plugins:
-  enabled: ["Coscheduling","CapacityScheduling","NodeResourceTopologyMatch","NodeResourcesAllocatable"]
-  disabled: ["PrioritySort"] # only in-tree plugins need to be defined here
+  queueSort:
+    enabled:
+      - name: TopologicalSort
+    disabled:
+      - name: "*"
+  preFilter:
+    enabled:
+      - name: NetworkOverhead
+  filter:
+    enabled:
+      - name: NetworkOverhead
+  score:
+    disabled: # Preferably avoid the combination of NodeResourcesFit with NetworkOverhead
+      - name: NodeResourcesFit
+    enabled: # A higher weight is given to NetworkOverhead to favor allocation schemes with lower latency.
+      - name: NetworkOverhead
+        weight: 5
+      - name: BalancedAllocation
+        weight: 1
 
 # Customize the enabled plugins' config.
 # Refer to the "pluginConfig" section of manifests/<plugin>/scheduler-config.yaml.
 # For example, for Coscheduling plugin, you want to customize the permit waiting timeout to 10 seconds:
 pluginConfig:
-- name: Coscheduling
+- name: TopologicalSort
   args:
-    permitWaitingTimeSeconds: 10 # default is 60
-# Or, customize the other plugins
-# - name: NodeResourceTopologyMatch
-#   args:
-#     scoringStrategy:
-#       type: MostAllocated # default is LeastAllocated
+    namespaces:
+      - "default"
+- name: NetworkOverhead
+  args:
+    namespaces:
+      - "default"
+    weightsName: "UserDefined" # The respective weights to consider in the plugins
+    networkTopologyName: "net-topology-test" # networkTopology CR to be used by the plugins


### PR DESCRIPTION
To install the helm chart:
- First, make sure you have a running K8s cluster with kubectl access.
- `cd manifests/install/charts/as-a-second-scheduler`
- `helm install scheduler-plugins . --create-namespace --namespace scheduler-plugins`

To uninstall the helm chart:
- `cd manifests/install/charts/as-a-second-scheduler`
- `helm uninstall scheduler-plugins -n scheduler-plugins`

We still need to create the network overhead config crd to make this fully usable.